### PR TITLE
fix: cloudflare worker not returning 404 page

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -14,6 +14,9 @@ async function handleEvent(event) {
         let response = await getAssetFromKV(event, options)
         return response
     } catch (e) {
-        return new Response(e.message || e.toString(), { status: 500 })
+        let response = await getAssetFromKV(event, {
+            mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/404.html`, req),
+        })
+        return new Response(response.body, { ...response, status: 404 })
     }
 }


### PR DESCRIPTION
This PR fixes the Cloudflare Workers script where the default 404.html
page is not shown to the user if the relevant asset cannot be retrieved
from the KV store.